### PR TITLE
Explicitly register commands (Symfony 4 compat)

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,6 +5,10 @@ parameters:
     cron.executor.class:        Cron\Executor\Executor
 
 services:
+    Cron\CronBundle\Command\:
+        resource: '../../Command'
+        tags: [console.command]
+
     cron.resolver:
         class: "%cron.resolver.class%"
         arguments: ["@cron.manager", "@cron.command_builder", "%kernel.root_dir%"]


### PR DESCRIPTION
Symfony 3.3 auto-tagged commands based on the convention of command classes being in the `Command` directory.

Such auto-tagging is deprecated as of Symfony 3.4 and has been removed as of Symfony 4.

This change explicitly tags command services such that:

- no deprecation notice is raised under Symfony 3.4
- commands continue to be registered under Symfony 4