### PR TITLE
CronRunCommand fixes

### DIFF
--- a/Command/CronRunCommand.php
+++ b/Command/CronRunCommand.php
@@ -103,6 +103,6 @@ class CronRunCommand extends ContainerAwareCommand
         $job = $this->getContainer()->get('cron.manager')
             ->getJobByName($jobName);
 
-        return ($job && $job->getEnabled()) ? $job : null;
+        return $job;
     }
 }

--- a/Command/CronRunCommand.php
+++ b/Command/CronRunCommand.php
@@ -89,7 +89,7 @@ class CronRunCommand extends ContainerAwareCommand
         $resolver = new ArrayResolver();
 
         $job = new ShellJob();
-        $job->setCommand(escapeshellarg($phpExecutable) . ' bin/console ' . $dbJob->getCommand(), $rootDir);
+        $job->setCommand(escapeshellarg($phpExecutable) . ' ' . $rootDir . '/bin/console ' . $dbJob->getCommand());
         $job->setSchedule(new CrontabSchedule($pattern));
         $job->raw = $dbJob;
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,13 @@ Disable a job.
 bin/console cron:run [--force] [job]
 ```
 > which we borrowed from Symfony. 
-> Make sure to check out [php-cs-fixer](https://github.com/fabpot/PHP-CS-Fixer) as this will help you a lot.
+> Make sure to check out [php-cs-fixer](https://github.com/fabpot/PHP-CS-Fixer) as this will help you a lot.  
+> Please note that `--force` forces the job to be executed (even if disabled) based on the job schedule  
+
+### run now, independent of the job schedule
+```shell
+bin/console cron:run --schedule_now [--force] job
+```
 
 ### start
 ```shell


### PR DESCRIPTION
I've encountered this while trying to execute a disabled command.
In `getJobResolver` the `$force` variable is used after checking if the `$dbJob` variable is null, but since we `($job && $job->getEnabled()) ? $job : null` in `queryJob`, `$dbJob` could be null because it is not enabled, thus `$force` never gets checked.