### PR TITLE
makes cron.validator public

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -26,3 +26,4 @@ services:
         arguments: ["%kernel.environment%"]
     cron.validator:
         class: "%cron.validator.class%"
+        public: true


### PR DESCRIPTION
Fixes **The "cron.validator" service or alias has been removed or inlined when the container was compiled..** issue for Symfony4.