### PR TITLE
Implementation of commands option --connection

### DIFF
--- a/Command/CronEnableCommand.php
+++ b/Command/CronEnableCommand.php
@@ -14,6 +14,8 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Cron\CronBundle\Cron\ManagerDecorator;
 
 /**
  * @author Dries De Peuter <dries@nousefreak.be>
@@ -21,13 +23,19 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CronEnableCommand extends ContainerAwareCommand
 {
     /**
+     * @var ManagerDecorator|null
+     */
+    private $cronManager;
+    
+    /**
      * {@inheritdoc}
      */
     protected function configure()
     {
         $this->setName('cron:enable')
             ->setDescription('Enable a cron job')
-            ->addArgument('job', InputArgument::REQUIRED, 'The job to enable');
+            ->addArgument('job', InputArgument::REQUIRED, 'The job to enable')
+            ->addOption('connection', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.');
     }
 
     /**
@@ -35,6 +43,8 @@ class CronEnableCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->cronManager = Helper\CronCommandHelper::setManagerHelper($this->getApplication(), $input);
+        
         $job = $this->queryJob($input->getArgument('job'));
 
         if (!$job) {
@@ -43,7 +53,7 @@ class CronEnableCommand extends ContainerAwareCommand
 
         $job->setEnabled(true);
 
-        $this->getContainer()->get('cron.manager')
+        $this->cronManager
             ->saveJob($job);
 
         $output->writeln(sprintf('Cron "%s" enabled', $job->getName()));
@@ -55,7 +65,7 @@ class CronEnableCommand extends ContainerAwareCommand
      */
     protected function queryJob($jobName)
     {
-        return $this->getContainer()->get('cron.manager')
+        return $this->cronManager
             ->getJobByName($jobName);
     }
 }

--- a/Command/CronRunCommand.php
+++ b/Command/CronRunCommand.php
@@ -32,7 +32,7 @@ class CronRunCommand extends ContainerAwareCommand
      * @var ManagerDecorator|null
      */
     private $cronManager;
-    
+
     /**
      * {@inheritdoc}
      */
@@ -41,7 +41,8 @@ class CronRunCommand extends ContainerAwareCommand
         $this->setName('cron:run')
             ->setDescription('Runs any currently schedule cron jobs')
             ->addArgument('job', InputArgument::OPTIONAL, 'Run only this job (if enabled)')
-            ->addOption('force', null, InputOption::VALUE_NONE, 'Force the current job.')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Force schedule the current job.')
+            ->addOption('schedule_now', null, InputOption::VALUE_NONE, 'Temporary set the job schedule to now.')
             ->addOption('connection', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.');
     }
 
@@ -55,7 +56,7 @@ class CronRunCommand extends ContainerAwareCommand
         $cron = new Cron();
         $cron->setExecutor($this->getContainer()->get('cron.executor'));
         if ($input->getArgument('job')) {
-            $resolver = $this->getJobResolver($input->getArgument('job'), $input->hasOption('force'));
+            $resolver = $this->getJobResolver($input->getArgument('job'), $input->getParameterOption('--force') !== false, $input->getParameterOption('--schedule_now') !== false);
         } else {
             $resolver = new ResolverDecorator($this->getContainer()->get('cron.resolver'), $this->cronManager);
         }
@@ -79,7 +80,7 @@ class CronRunCommand extends ContainerAwareCommand
      * @return ArrayResolver
      * @throws \InvalidArgumentException
      */
-    protected function getJobResolver($jobName, $force = false)
+    protected function getJobResolver($jobName, $force = false, $schedule_now = false)
     {
         $dbJob = $this->queryJob($jobName);
 
@@ -87,20 +88,23 @@ class CronRunCommand extends ContainerAwareCommand
             throw new \InvalidArgumentException('Unknown job.');
         }
 
+        if (!$dbJob->getEnabled() && !$force) {
+            throw new \InvalidArgumentException('Job is disabled, run with --force to force schedule it.');
+        }
+
         $finder = new PhpExecutableFinder();
         $phpExecutable = $finder->find();
         $rootDir = dirname($this->getContainer()->getParameter('kernel.root_dir'));
+        $pattern = !$schedule_now ? $dbJob->getSchedule() : '* * * * *';
 
         $resolver = new ArrayResolver();
 
-        if ($dbJob->getEnabled() || $force) {
-            $job = new ShellJob();
-            $job->setCommand(escapeshellarg($phpExecutable) . ' bin/console ' . $dbJob->getCommand(), $rootDir);
-            $job->setSchedule(new CrontabSchedule($dbJob->getSchedule()));
-            $job->raw = $dbJob;
+        $job = new ShellJob();
+        $job->setCommand(escapeshellarg($phpExecutable) . ' ' . $rootDir . '/bin/console ' . $dbJob->getCommand());
+        $job->setSchedule(new CrontabSchedule($pattern));
+        $job->raw = $dbJob;
 
-            $resolver->addJob($job);
-        }
+        $resolver->addJob($job);
 
         return $resolver;
     }
@@ -114,6 +118,6 @@ class CronRunCommand extends ContainerAwareCommand
         $job = $this->cronManager
             ->getJobByName($jobName);
 
-        return ($job && $job->getEnabled()) ? $job : null;
+        return $job;
     }
 }

--- a/Command/CronRunCommand.php
+++ b/Command/CronRunCommand.php
@@ -42,8 +42,8 @@ class CronRunCommand extends ContainerAwareCommand
             ->setDescription('Runs any currently schedule cron jobs')
             ->addArgument('job', InputArgument::OPTIONAL, 'Run only this job (if enabled)')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Force schedule the current job.')
-            ->addOption('schedule_now', null, InputOption::VALUE_NONE, 'Temporary set the job schedule to now.')
-            ->addOption('connection', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.');
+            ->addOption('connection', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
+            ->addOption('schedule_now', null, InputOption::VALUE_NONE, 'Temporary set the job schedule to now.');
     }
 
     /**

--- a/Command/Helper/CronCommandHelper.php
+++ b/Command/Helper/CronCommandHelper.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of the SymfonyCronBundle package.
+ *
+ * (c) Dries De Peuter <dries@nousefreak.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Cron\CronBundle\Command\Helper;
+
+use Cron\CronBundle\Cron\ManagerDecorator;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+abstract class CronCommandHelper
+{
+    public static function setManagerHelper(Application $application, InputInterface $input)
+    {            
+        $connection = $application->getKernel()->getContainer()->get('doctrine')->getConnection($input->getOption('connection'));
+
+        $em = $application->getKernel()->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $em->create($connection, $em->getConfiguration());
+
+        $cronManager = new ManagerDecorator($application->getKernel()->getContainer()->get('cron.manager'), $em);
+        
+        return $cronManager;
+    }
+}

--- a/Cron/Manager.php
+++ b/Cron/Manager.php
@@ -64,8 +64,8 @@ class Manager
     {
         return $this->getJobRepo()
             ->findBy(array(), array(
-                    'name' => 'asc',
-                ));
+                'name' => 'asc',
+            ));
     }
 
     /**
@@ -75,10 +75,10 @@ class Manager
     {
         return $this->getJobRepo()
             ->findBy(array(
-                    'enabled' => 1,
-                ), array(
-                    'name' => 'asc',
-                ));
+                'enabled' => 1,
+            ), array(
+                'name' => 'asc',
+            ));
     }
 
     /**
@@ -98,8 +98,8 @@ class Manager
     {
         return $this->getJobRepo()
             ->findOneBy(array(
-                    'name' => $name,
-                ));
+                'name' => $name,
+            ));
     }
 
     /**

--- a/Cron/ManagerDecorator.php
+++ b/Cron/ManagerDecorator.php
@@ -9,11 +9,7 @@
  */
 namespace Cron\CronBundle\Cron;
 
-use Cron\CronBundle\Entity\CronJob;
-use Cron\CronBundle\Entity\CronJobRepository;
-use Cron\CronBundle\Entity\CronReport;
 use Doctrine\ORM\EntityManager;
-use eZ\Publish\Core\Repository\Repository;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 
 /**

--- a/Cron/ManagerDecorator.php
+++ b/Cron/ManagerDecorator.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This file is part of the SymfonyCronBundle package.
+ *
+ * (c) Dries De Peuter <dries@nousefreak.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Cron\CronBundle\Cron;
+
+use Cron\CronBundle\Entity\CronJob;
+use Cron\CronBundle\Entity\CronJobRepository;
+use Cron\CronBundle\Entity\CronReport;
+use Doctrine\ORM\EntityManager;
+use eZ\Publish\Core\Repository\Repository;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+/**
+ * @author Dries De Peuter <dries@nousefreak.be>
+ */
+class ManagerDecorator extends Manager
+{
+    /**
+     * @param RegistryInterface $registry
+     */
+    function __construct(Manager $manager, EntityManager $em)
+    {
+        $this->manager = $em;
+    }
+}

--- a/Cron/Resolver.php
+++ b/Cron/Resolver.php
@@ -24,17 +24,17 @@ class Resolver implements ResolverInterface
     /**
      * @var Manager
      */
-    private $manager;
+    protected $manager;
 
     /**
      * @var CommandBuilder
      */
-    private $commandBuilder;
+    protected $commandBuilder;
 
     /**
      * @var string
      */
-    private $rootDir;
+    protected $rootDir;
 
 
     public function __construct(Manager $manager, CommandBuilder $commandBuilder, $rootDir)
@@ -42,7 +42,6 @@ class Resolver implements ResolverInterface
         $this->manager = $manager;
         $this->commandBuilder = $commandBuilder;
         $this->rootDir = dirname($rootDir);
-
     }
 
     /**

--- a/Cron/ResolverDecorator.php
+++ b/Cron/ResolverDecorator.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of the SymfonyCronBundle package.
+ *
+ * (c) Dries De Peuter <dries@nousefreak.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Cron\CronBundle\Cron;
+
+use Cron\CronBundle\Cron\ManagerDecorator;
+use Cron\Resolver\ResolverInterface;
+
+/**
+ * @author Dries De Peuter <dries@nousefreak.be>
+ */
+class ResolverDecorator extends Resolver
+{
+    /**
+     * @param RegistryInterface $registry
+     */
+    function __construct(ResolverInterface $resolver, ManagerDecorator $manager)
+    {
+        $this->manager = $manager;
+        $this->commandBuilder = $resolver->commandBuilder;
+        $this->rootDir = $resolver->rootDir;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -95,7 +95,13 @@ Disable a job.
 bin/console cron:run [--force] [job]
 ```
 > which we borrowed from Symfony. 
-> Make sure to check out [php-cs-fixer](https://github.com/fabpot/PHP-CS-Fixer) as this will help you a lot.
+> Make sure to check out [php-cs-fixer](https://github.com/fabpot/PHP-CS-Fixer) as this will help you a lot.  
+> Please note that `--force` forces the job to be executed (even if disabled) based on the job schedule  
+
+### run now, independent of the job schedule
+```shell
+bin/console cron:run --schedule_now [--force] job
+```
 
 ### start
 ```shell

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -26,7 +26,7 @@ services:
     cron.manager_decorator:
         class: Cron\CronBundle\Cron\ManagerDecorator
         decorates: cron.manager
-        arguments: ["@cron.manager_decorator.inner", "@doctrine.orm.default_entity_manager"]
+        arguments: ["@cron.manager_decorator.inner", "@doctrine.orm.entity_manager"]
         public: true
     cron.executor:
         class: "%cron.executor.class%"

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -14,9 +14,19 @@ services:
         class: "%cron.resolver.class%"
         arguments: ["@cron.manager", "@cron.command_builder", "%kernel.root_dir%"]
         public: true
+    cron.resolver_decorator:
+        class: Cron\CronBundle\Cron\ResolverDecorator
+        decorates: cron.resolver
+        arguments: ["@cron.resolver_decorator.inner", "@cron.manager_decorator"]
+        public: true
     cron.manager:
         class: "%cron.manager.class%"
         arguments: ["@doctrine"]
+        public: true
+    cron.manager_decorator:
+        class: Cron\CronBundle\Cron\ManagerDecorator
+        decorates: cron.manager
+        arguments: ["@cron.manager_decorator.inner", "@doctrine.orm.entity_manager"]
         public: true
     cron.executor:
         class: "%cron.executor.class%"

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -26,7 +26,7 @@ services:
     cron.manager_decorator:
         class: Cron\CronBundle\Cron\ManagerDecorator
         decorates: cron.manager
-        arguments: ["@cron.manager_decorator.inner", "@doctrine.orm.entity_manager"]
+        arguments: ["@cron.manager_decorator.inner", "@doctrine.orm.default_entity_manager"]
         public: true
     cron.executor:
         class: "%cron.executor.class%"

--- a/Tests/Fixtures/App/app/config/config.yml
+++ b/Tests/Fixtures/App/app/config/config.yml
@@ -13,3 +13,5 @@ doctrine:
             default:
                 driver:   pdo_sqlite
                 memory:   true
+    orm:
+        auto_mapping: true

--- a/Tests/Fixtures/App/app/config/config.yml
+++ b/Tests/Fixtures/App/app/config/config.yml
@@ -15,4 +15,4 @@ doctrine:
                 memory:   true
     orm:
         auto_mapping: true
-        naming_strategy: doctrine.orm.naming_strategy.default
+        naming_strategy: doctrine.orm.naming_strategy.underscore

--- a/Tests/Fixtures/App/app/config/config.yml
+++ b/Tests/Fixtures/App/app/config/config.yml
@@ -15,3 +15,4 @@ doctrine:
                 memory:   true
     orm:
         auto_mapping: true
+        naming_strategy: doctrine.orm.naming_strategy.default


### PR DESCRIPTION
This PR adds new option "connection" to commands.

In an installation with multiple databases you can determine which connection to use for command.

As value for connection option the configured name is used (eg "mystorage1"):

`doctrine:
    dbal:
        connections:
            mystorage1:
               ...
            mystorage2:
               ...
    orm:
        auto_mapping: true`

To achieve this service decorators are implemented for Manager and Resolver class in order to inject entity manager with given connection.

Moreover it is respected that start command transfers the connection option (if it is set) to run command.