### PR TITLE
Fix to handle warning for use of deprecated ContainerAwareCommand

### DIFF
--- a/Command/CronCreateCommand.php
+++ b/Command/CronCreateCommand.php
@@ -9,8 +9,8 @@
  */
 namespace Cron\CronBundle\Command;
 
+use Cron\CronBundle\Cron\CronCommand;
 use Cron\CronBundle\Entity\CronJob;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @author Dries De Peuter <dries@nousefreak.be>
  */
-class CronCreateCommand extends ContainerAwareCommand
+class CronCreateCommand extends CronCommand
 {
     /**
      * {@inheritdoc}

--- a/Command/CronDeleteCommand.php
+++ b/Command/CronDeleteCommand.php
@@ -9,8 +9,8 @@
  */
 namespace Cron\CronBundle\Command;
 
+use Cron\CronBundle\Cron\CronCommand;
 use Cron\CronBundle\Entity\CronJob;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @author Dries De Peuter <dries@nousefreak.be>
  */
-class CronDeleteCommand extends ContainerAwareCommand
+class CronDeleteCommand extends CronCommand
 {
     /**
      * {@inheritdoc}

--- a/Command/CronDisableCommand.php
+++ b/Command/CronDisableCommand.php
@@ -9,8 +9,8 @@
  */
 namespace Cron\CronBundle\Command;
 
+use Cron\CronBundle\Cron\CronCommand;
 use Cron\CronBundle\Entity\CronJob;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @author Dries De Peuter <dries@nousefreak.be>
  */
-class CronDisableCommand extends ContainerAwareCommand
+class CronDisableCommand extends CronCommand
 {
     /**
      * {@inheritdoc}

--- a/Command/CronEnableCommand.php
+++ b/Command/CronEnableCommand.php
@@ -9,8 +9,8 @@
  */
 namespace Cron\CronBundle\Command;
 
+use Cron\CronBundle\Cron\CronCommand;
 use Cron\CronBundle\Entity\CronJob;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @author Dries De Peuter <dries@nousefreak.be>
  */
-class CronEnableCommand extends ContainerAwareCommand
+class CronEnableCommand extends CronCommand
 {
     /**
      * {@inheritdoc}

--- a/Command/CronListCommand.php
+++ b/Command/CronListCommand.php
@@ -9,15 +9,17 @@
  */
 namespace Cron\CronBundle\Command;
 
+use Cron\CronBundle\Cron\CronCommand;
 use Cron\CronBundle\Entity\CronJob;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @author Dries De Peuter <dries@nousefreak.be>
  */
-class CronListCommand extends ContainerAwareCommand
+class CronListCommand extends CronCommand
 {
     /**
      * {@inheritdoc}

--- a/Command/CronRunCommand.php
+++ b/Command/CronRunCommand.php
@@ -10,11 +10,11 @@
 namespace Cron\CronBundle\Command;
 
 use Cron\Cron;
+use Cron\CronBundle\Cron\CronCommand;
 use Cron\CronBundle\Entity\CronJob;
 use Cron\Job\ShellJob;
 use Cron\Resolver\ArrayResolver;
 use Cron\Schedule\CrontabSchedule;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -24,7 +24,7 @@ use Symfony\Component\Process\PhpExecutableFinder;
 /**
  * @author Dries De Peuter <dries@nousefreak.be>
  */
-class CronRunCommand extends ContainerAwareCommand
+class CronRunCommand extends CronCommand
 {
     /**
      * {@inheritdoc}

--- a/Command/CronStartCommand.php
+++ b/Command/CronStartCommand.php
@@ -10,7 +10,7 @@
 
 namespace Cron\CronBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Cron\CronBundle\Cron\CronCommand;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @author Alexander Lokhman <alex.lokhman@gmail.com>
  */
-class CronStartCommand extends ContainerAwareCommand
+class CronStartCommand extends CronCommand
 {
     const PID_FILE = '.cron-pid';
 

--- a/Command/CronStopCommand.php
+++ b/Command/CronStopCommand.php
@@ -10,14 +10,14 @@
 
 namespace Cron\CronBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Cron\CronBundle\Cron\CronCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @author Alexander Lokhman <alex.lokhman@gmail.com>
  */
-class CronStopCommand extends ContainerAwareCommand
+class CronStopCommand extends CronCommand
 {
     /**
      * {@inheritdoc}

--- a/Cron/CronCommand.php
+++ b/Cron/CronCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace Cron\CronBundle\Cron;
+
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+abstract class CronCommand extends Command
+{
+    /** ContainerInterface $container */
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+        parent::__construct();
+    }
+
+    public function getContainer()
+    {
+        return $this->container;
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -8,8 +8,8 @@ parameters:
 services:
     Cron\CronBundle\Command\:
         resource: '../../Command'
+        arguments: [ "@service_container"]
         tags: [console.command]
-
     cron.resolver:
         class: "%cron.resolver.class%"
         arguments: ["@cron.manager", "@cron.command_builder", "%kernel.root_dir%"]

--- a/Tests/Command/CronDisableCommandTest.php
+++ b/Tests/Command/CronDisableCommandTest.php
@@ -79,7 +79,7 @@ class CronDisableCommandTest extends WebTestCase
         $kernel->getContainer()->set('cron.manager', $manager);
 
         $application = new Application($kernel);
-        $application->add(new CronDisableCommand());
+        $application->add(new CronDisableCommand($kernel->getContainer()));
 
         return $application->find('cron:disable');
     }

--- a/Tests/Command/CronEnableCommandTest.php
+++ b/Tests/Command/CronEnableCommandTest.php
@@ -79,7 +79,7 @@ class CronEnableCommandTest extends WebTestCase
         $kernel->getContainer()->set('cron.manager', $manager);
 
         $application = new Application($kernel);
-        $application->add(new CronEnableCommand());
+        $application->add(new CronEnableCommand($kernel->getContainer()));
 
         return $application->find('cron:enable');
     }

--- a/Tests/Command/CronRunCommandTest.php
+++ b/Tests/Command/CronRunCommandTest.php
@@ -100,7 +100,7 @@ class CronRunCommandTest extends WebTestCase
         $kernel->getContainer()->set('cron.resolver', $resolver);
 
         $application = new Application($kernel);
-        $application->add(new \Cron\CronBundle\Command\CronRunCommand());
+        $application->add(new \Cron\CronBundle\Command\CronRunCommand($kernel->getContainer()));
 
         return $application->find('cron:run');
     }


### PR DESCRIPTION
Basically what I did is created a base class for all the commands (CronCommand.php) the constructor receives the Container as defined in services.yml. 