### PR TITLE
replace depricated kernel.root_dir with kernel.project_dir

### DIFF
--- a/Command/CronRunCommand.php
+++ b/Command/CronRunCommand.php
@@ -85,7 +85,7 @@ class CronRunCommand extends CronCommand
 
         $finder = new PhpExecutableFinder();
         $phpExecutable = $finder->find();
-        $rootDir = dirname($this->getContainer()->getParameter('kernel.root_dir'));
+        $rootDir = $this->getContainer()->getParameter('kernel.project_dir');
         $pattern = !$schedule_now ? $dbJob->getSchedule() : '* * * * *';
 
         $resolver = new ArrayResolver();

--- a/Cron/Resolver.php
+++ b/Cron/Resolver.php
@@ -41,7 +41,7 @@ class Resolver implements ResolverInterface
     {
         $this->manager = $manager;
         $this->commandBuilder = $commandBuilder;
-        $this->rootDir = dirname($rootDir);
+        $this->rootDir = $rootDir;
 
     }
 


### PR DESCRIPTION
https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-the-kernel-name-and-the-root-dir

