### PR TITLE
Added support __toString() method in CronJob entity.

### DIFF
--- a/Entity/CronJob.php
+++ b/Entity/CronJob.php
@@ -192,4 +192,9 @@ class CronJob
     {
         return $this->reports;
     }
+
+    public function __toString()
+    {
+        return $this->name;
+    }
 }


### PR DESCRIPTION
In projects like easyadmin, automcomplete is based on toString this is
not MappedSuperclass and it is hard to overwrite in Doctrine/Symfony