### PR TITLE
fix: wakeup server if needed

### DIFF
--- a/Cron/Manager.php
+++ b/Cron/Manager.php
@@ -14,6 +14,7 @@ use Cron\CronBundle\Entity\CronJobRepository;
 use Cron\CronBundle\Entity\CronReport;
 use Doctrine\Persistence\ManagerRegistry;
 use Cron\Report\JobReport;
+use Doctrine\DBAL\Connection;
 
 /**
  * @author Dries De Peuter <dries@nousefreak.be>
@@ -46,6 +47,11 @@ class Manager
      */
     public function saveReports(array $reports)
     {
+        $connection = $this->manager->getConnection();
+        if($connection instanceof Connection && false === $connection->ping()){
+            $connection->close();
+            $connection->connect();
+        }
         foreach ($reports as $report) {
             $dbReport = new CronReport();
             $dbReport->setJob($report->getJob()->raw);


### PR DESCRIPTION
Hello,

I am facing an issue using this bundle for long running commands.

When the bundle try to create cron reports, I obtain this error message : "SQLSTATE[HY000]: General error: 2006 MySQL server has gone away".
I have found two solutions :
- Increase MySQL variables **connect_timeout**, **wait_timeout**, **interactive_timeout**, but it's seems to me not very secure
- Reopen the connection if it is closed (this PR)

What do you think about this ?

Thanks in advance for your help,
Jacques




