### PR TITLE
Add a way to specify the script name to run cron:run command from non…

### DIFF
--- a/Command/CronRunCommand.php
+++ b/Command/CronRunCommand.php
@@ -36,7 +36,7 @@ class CronRunCommand extends CronCommand
             ->addArgument('job', InputArgument::OPTIONAL, 'Run only this job (if enabled)')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Force schedule the current job.')
             ->addOption('schedule_now', null, InputOption::VALUE_NONE, 'Temporary set the job schedule to now.')
-            ->addOption('script_name', null, InputOption::VALUE_OPTIONAL, 'Specify this to avoid guessing the script name to run the command in non-CLI context.');
+            ->addOption('script-name', null, InputOption::VALUE_OPTIONAL, 'Specify this to avoid guessing the script name to run the command in non-CLI context.');
     }
 
     /**
@@ -52,8 +52,8 @@ class CronRunCommand extends CronCommand
             $resolver = $this->getContainer()->get('cron.resolver');
         }
 
-        if($input->getParameterOption('--script_name') !== false) {
-            $resolver->setScriptName((string)$input->getParameterOption('--script_name'));
+        if($input->getParameterOption('--script-name') !== false) {
+            $resolver->setScriptName((string)$input->getParameterOption('--script-name'));
         }
 
         $cron->setResolver($resolver);

--- a/Command/CronRunCommand.php
+++ b/Command/CronRunCommand.php
@@ -35,7 +35,8 @@ class CronRunCommand extends CronCommand
             ->setDescription('Runs any currently schedule cron jobs')
             ->addArgument('job', InputArgument::OPTIONAL, 'Run only this job (if enabled)')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Force schedule the current job.')
-            ->addOption('schedule_now', null, InputOption::VALUE_NONE, 'Temporary set the job schedule to now.');
+            ->addOption('schedule_now', null, InputOption::VALUE_NONE, 'Temporary set the job schedule to now.')
+            ->addOption('script_name', null, InputOption::VALUE_OPTIONAL, 'Specify this to avoid guessing the script name to run the command in non-CLI context.');
     }
 
     /**
@@ -50,6 +51,11 @@ class CronRunCommand extends CronCommand
         } else {
             $resolver = $this->getContainer()->get('cron.resolver');
         }
+
+        if($input->getParameterOption('--script_name') !== false) {
+            $resolver->setScriptName((string)$input->getParameterOption('--script_name'));
+        }
+
         $cron->setResolver($resolver);
 
         $time = microtime(true);

--- a/Cron/CommandBuilder.php
+++ b/Cron/CommandBuilder.php
@@ -42,8 +42,8 @@ class CommandBuilder
      *
      * @return string
      */
-    public function build($command)
+    public function build($command, $scriptName = null)
     {
-        return sprintf('%s %s %s --env=%s', $this->phpExecutable, $_SERVER['SCRIPT_NAME'], $command, $this->environment);
+        return sprintf('%s %s %s --env=%s', $this->phpExecutable, $scriptName ?? $_SERVER['SCRIPT_NAME'], $command, $this->environment);
     }
 }

--- a/Cron/Resolver.php
+++ b/Cron/Resolver.php
@@ -36,13 +36,17 @@ class Resolver implements ResolverInterface
      */
     private $rootDir;
 
+    /**
+     * @var string
+     */
+    private $scriptName;
+
 
     public function __construct(Manager $manager, CommandBuilder $commandBuilder, $rootDir)
     {
         $this->manager = $manager;
         $this->commandBuilder = $commandBuilder;
         $this->rootDir = $rootDir;
-
     }
 
     /**
@@ -58,6 +62,16 @@ class Resolver implements ResolverInterface
     }
 
     /**
+     * Overrides the script name used by the command builder to build the command.
+     *
+     * @param string $scriptName
+     */
+    public function setScriptName($scriptName)
+    {
+        $this->scriptName = $scriptName;
+    }
+
+    /**
      * Transform a CronJon into a ShellJob.
      *
      * @param  CronJob  $dbJob
@@ -66,7 +80,7 @@ class Resolver implements ResolverInterface
     protected function createJob(CronJob $dbJob)
     {
         $job = new ShellJob();
-        $job->setCommand($this->commandBuilder->build($dbJob->getCommand()), $this->rootDir);
+        $job->setCommand($this->commandBuilder->build($dbJob->getCommand(), $this->scriptName), $this->rootDir);
         $job->setSchedule(new CrontabSchedule($dbJob->getSchedule()));
         $job->raw = $dbJob;
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ bin/console cron:run --schedule_now [--force] job
 
 ### run in non-cli contexts (i.e. [from a controller](https://symfony.com/doc/current/console/command_in_controller.html))
 ```shell
-bin/console cron:run --script_name='bin/console'
+bin/console cron:run --script-name='bin/console'
 ```
 
 ### start

--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ bin/console cron:run [--force] [job]
 bin/console cron:run --schedule_now [--force] job
 ```
 
+### run in non-cli contexts (i.e. [from a controller](https://symfony.com/doc/current/console/command_in_controller.html))
+```shell
+bin/console cron:run --script_name='bin/console'
+```
+
 ### start
 ```shell
 bin/console cron:start [--blocking]


### PR DESCRIPTION
…-CLI contexts

This PR is in response to this issue https://github.com/Cron/Symfony-Bundle/issues/89

It implements a way to specify the script name to run the command from non-CLI context (i.e. apache2handler, etc.)

That way, it's possible to call the cron:run command from a controller, on hostings where it's needed.
```
<?php

namespace App\Controller;

use Symfony\Bundle\FrameworkBundle\Console\Application;
use Symfony\Component\Console\Input\ArrayInput;
use Symfony\Component\Console\Output\BufferedOutput;
use Symfony\Component\HttpFoundation\Response;
use Symfony\Component\HttpKernel\KernelInterface;
use Symfony\Component\Routing\Annotation\Route;

class CronController extends BaseAppController
{
    /**
     * @Route("/cron/run", name="cron_run_endpoint")
     */
    public function endpoint(KernelInterface $kernel): Response
    {
        $application = new Application($kernel);
        $application->setAutoExit(false);

        $input = new ArrayInput([
            'command' => 'cron:run',
            '--script_name' => 'bin/console',
        ]);

        $output = new BufferedOutput();

        $application->run($input, $output);

        $content = $output->fetch();

        return new Response($content);
    }
}

```

Please let me know if you need anything more to accept and merge the PR.