### PR TITLE
fix integer decimal pointer for locales not using "."

### DIFF
--- a/Cron/Manager.php
+++ b/Cron/Manager.php
@@ -51,7 +51,7 @@ class Manager
             $dbReport->setJob($report->getJob()->raw);
             $dbReport->setOutput(implode("\n", (array) $report->getOutput()));
             $dbReport->setExitCode($report->getJob()->getProcess()->getExitCode());
-            $dbReport->setRunAt(\DateTime::createFromFormat('U.u', (string) $report->getStartTime()));
+            $dbReport->setRunAt(\DateTime::createFromFormat('U.u', number_format($report->getStartTime(), 6, '.', '')));
             $dbReport->setRunTime($report->getEndTime() - $report->getStartTime());
             $em->persist($dbReport);
         }


### PR DESCRIPTION
Hello

I have copied your solution for locales that are not using "." as decimal separator to version 1.x that doesnt require newer php than 7.0 is possible to approve it? I cannot use newer version of php because of company rules.

Best regards
Fabricio872