### PR TITLE
CPU overloading problem

### DIFF
--- a/Command/CronRunCommand.php
+++ b/Command/CronRunCommand.php
@@ -55,7 +55,9 @@ class CronRunCommand extends CronCommand
         $time = microtime(true);
         $dbReport = $cron->run();
 
-        while ($cron->isRunning()) {}
+        while ($cron->isRunning()) {
+            sleep(0.1);
+        }
 
         $output->writeln('time: ' . (microtime(true) - $time));
 


### PR DESCRIPTION
### Hello

I have found out that when I have a long running process, this command is constantly checking if it is finished as fast as it can, and that is unnecessarily loading one core to 100%. So i have implemented simple sleep command for 100ms in the waiting loop. That means now it lost some accuracy to determine how long a command is running but overhead of the process is now very low. If you have a better solution please feel free to implement it.

Best regards
Fabricio872