### PR TITLE
Update Manager.php to fix DBAL3.0 incompatibility

### DIFF
--- a/Cron/Manager.php
+++ b/Cron/Manager.php
@@ -56,6 +56,11 @@ class Manager
      */
     public function saveReports(array $reports)
     {
+        $connection = $this->manager->getConnection();
+        if($connection instanceof Connection && true === method_exists($connection, 'ping') && false === $connection->ping()){
+            $connection->close();
+            $connection->connect();
+        }
         foreach ($reports as $report) {
             $dbReport = new CronReport();
             $dbReport->setJob($report->getJob()->raw);
@@ -74,6 +79,11 @@ class Manager
      */
     public function truncateReports(int $days = 3)
     {        
+        $connection = $this->manager->getConnection();
+        if($connection instanceof Connection && true === method_exists($connection, 'ping') && false === $connection->ping()){
+            $connection->close();
+            $connection->connect();
+        }
         $queryBuilder = $this->getReportRepo()->createQueryBuilder('cr');
 
         $dateToClear = (new \DateTime('today'))

--- a/Cron/Manager.php
+++ b/Cron/Manager.php
@@ -56,11 +56,6 @@ class Manager
      */
     public function saveReports(array $reports)
     {
-        $connection = $this->manager->getConnection();
-        if($connection instanceof Connection && false === $connection->ping()){
-            $connection->close();
-            $connection->connect();
-        }
         foreach ($reports as $report) {
             $dbReport = new CronReport();
             $dbReport->setJob($report->getJob()->raw);
@@ -78,13 +73,7 @@ class Manager
      * @param int $days
      */
     public function truncateReports(int $days = 3)
-    {
-        $connection = $this->manager->getConnection();
-        if($connection instanceof Connection && false === $connection->ping()){
-            $connection->close();
-            $connection->connect();
-        }
-        
+    {        
         $queryBuilder = $this->getReportRepo()->createQueryBuilder('cr');
 
         $dateToClear = (new \DateTime('today'))


### PR DESCRIPTION
Remove the DBAL ping function, not supported anymore in DBAL 3.0. DBAL 3.0 check himself if the connection is up and reconnect if not, so no need to check it.