### PR TITLE
Bugfix: Implicit conversion from float 0.1 to int loses precision.

### DIFF
--- a/Command/CronRunCommand.php
+++ b/Command/CronRunCommand.php
@@ -66,7 +66,7 @@ class CronRunCommand extends CronCommand
         $dbReport = $cron->run();
 
         while ($cron->isRunning()) {
-            sleep(0.1);
+            time_nanosleep(0, 100000000);
         }
 
         $output->writeln('time: ' . (microtime(true) - $time));


### PR DESCRIPTION
Sleep only accepts an int value, so 0.1 second wasn't a valid value.

I'm having problems running the original code in PHP 8, because of the error: "Implicit conversion from float 0.1 to int loses precision."

By using time_nanosleep this problem is solved.