### PR TITLE
Bugfix: Implicit conversion from float to int loses precision.

### DIFF
--- a/Command/CronRunCommand.php
+++ b/Command/CronRunCommand.php
@@ -66,7 +66,7 @@ class CronRunCommand extends CronCommand
         $dbReport = $cron->run();
 
         while ($cron->isRunning()) {
-            sleep(0.1);
+            time_nanosleep(0, 100000000);
         }
 
         $output->writeln('time: ' . (microtime(true) - $time));

--- a/Command/CronStartCommand.php
+++ b/Command/CronStartCommand.php
@@ -86,7 +86,9 @@ class CronStartCommand extends CronCommand
 
         while (true) {
             $now = microtime(true);
-            usleep((60 - ($now % 60) + (int) $now - $now) * 1e6);
+            $intNow = (int) $now;
+            $microseconds = (60 - ($intNow % 60) + $intNow - $now) * 1e6;
+            usleep((int) $microseconds);
 
             if (null !== $pidFile && !file_exists($pidFile)) {
                 break;


### PR DESCRIPTION
Modulo and usleep only accept an int value, so we need to explicit cast it to an int.

**PHP 8.1: Implicit incompatible float to int conversion is deprecated**
@see: https://php.watch/versions/8.1/deprecate-implicit-conversion-incompatible-float-string