### PR TITLE
Allow use of cron:delete without interaction

### DIFF
--- a/Command/CronDeleteCommand.php
+++ b/Command/CronDeleteCommand.php
@@ -52,7 +52,13 @@ class CronDeleteCommand extends CronCommand
 
         $output->writeln(sprintf('<info>You are about to delete "%s".</info>', $job->getName()));
 
-        $question = new ConfirmationQuestion('<question>Delete this job</question> [N/y]: ', false, '/^(y)/i');
+        // Defaults to NO if input is interactive
+        // Defaults to YES otherwise
+        $question = new ConfirmationQuestion(
+            '<question>Delete this job</question> [N/y]: ',
+            $input->isInteractive(),
+            '/^(y)/i'
+        );
 
         if (!$this->getQuestionHelper()->ask($input, $output, $question)) {
             return;


### PR DESCRIPTION
This PR changes the behaviour of the `cron:delete` command.

Makes the `cron:delete` command behaviour default to delete instead of abort when launched with a non-interactive input.