### PR TITLE
Fix PHP 8.2 Dynamic Properties deprecation

### DIFF
--- a/Command/CronRunCommand.php
+++ b/Command/CronRunCommand.php
@@ -12,7 +12,7 @@ namespace Cron\CronBundle\Command;
 use Cron\Cron;
 use Cron\CronBundle\Cron\CronCommand;
 use Cron\CronBundle\Entity\CronJob;
-use Cron\Job\ShellJob;
+use Cron\CronBundle\Job\ShellJobWrapper;
 use Cron\Resolver\ArrayResolver;
 use Cron\Schedule\CrontabSchedule;
 use Symfony\Component\Console\Input\InputArgument;
@@ -102,7 +102,7 @@ class CronRunCommand extends CronCommand
 
         $resolver = new ArrayResolver();
 
-        $job = new ShellJob();
+        $job = new ShellJobWrapper();
         $job->setCommand(escapeshellarg($phpExecutable) . ' --define max_execution_time='.ini_get('max_execution_time').' --define memory_limit='.ini_get('memory_limit').' ' . $rootDir . '/bin/console ' . $dbJob->getCommand());
         $job->setSchedule(new CrontabSchedule($pattern));
         $job->raw = $dbJob;

--- a/Cron/Manager.php
+++ b/Cron/Manager.php
@@ -13,6 +13,7 @@ use Cron\CronBundle\Entity\CronJob;
 use Cron\CronBundle\Entity\CronJobRepository;
 use Cron\CronBundle\Entity\CronReport;
 use Cron\CronBundle\Entity\CronReportRepository;
+use Cron\CronBundle\Job\ShellJobWrapper;
 use Doctrine\Persistence\ManagerRegistry;
 use Cron\Report\JobReport;
 use Doctrine\DBAL\Connection;
@@ -62,8 +63,12 @@ class Manager
             $connection->connect();
         }
         foreach ($reports as $report) {
+            $job = $report->getJob();
+            if (! $job instanceof ShellJobWrapper) {
+                continue;
+            }
             $dbReport = new CronReport();
-            $dbReport->setJob($report->getJob()->raw);
+            $dbReport->setJob($job->raw);
             $dbReport->setOutput(implode("\n", (array) $report->getOutput()));
             $dbReport->setError(implode("\n", (array) $report->getError()));
             $dbReport->setExitCode($report->getJob()->getProcess()->getExitCode());

--- a/Cron/Resolver.php
+++ b/Cron/Resolver.php
@@ -10,6 +10,7 @@
 namespace Cron\CronBundle\Cron;
 
 use Cron\CronBundle\Entity\CronJob;
+use Cron\CronBundle\Job\ShellJobWrapper;
 use Cron\Job\JobInterface;
 use Cron\Job\ShellJob;
 use Cron\Resolver\ResolverInterface;
@@ -79,7 +80,7 @@ class Resolver implements ResolverInterface
      */
     protected function createJob(CronJob $dbJob)
     {
-        $job = new ShellJob();
+        $job = new ShellJobWrapper();
         $job->setCommand($this->commandBuilder->build($dbJob->getCommand(), $this->scriptName), $this->rootDir);
         $job->setSchedule(new CrontabSchedule($dbJob->getSchedule()));
         $job->raw = $dbJob;

--- a/Job/ShellJobWrapper.php
+++ b/Job/ShellJobWrapper.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Cron\CronBundle\Job;
+
+use Cron\CronBundle\Entity\CronJob;
+use Cron\Job\ShellJob;
+
+class ShellJobWrapper extends ShellJob
+{
+    /**
+     * @var CronJob
+     */
+    public $raw;
+}


### PR DESCRIPTION
PHP 8.2 [deprecates dynamic properties](https://www.php.net/releases/8.2/en.php#deprecate_dynamic_properties). 
Original Cron\Job\ShellJob doesn't declare the $raw property.