### PR TITLE
Timezone fix in database reports

### DIFF
--- a/Cron/Manager.php
+++ b/Cron/Manager.php
@@ -68,6 +68,7 @@ class Manager
             $dbReport->setError(implode("\n", (array) $report->getError()));
             $dbReport->setExitCode($report->getJob()->getProcess()->getExitCode());
             $dbReport->setRunAt(\DateTime::createFromFormat('U.u', number_format($report->getStartTime(), 6, '.', '')));
+            $dbReport->getRunAt()->setTimezone(new \DateTimeZone(getenv('TZ') ?: date_default_timezone_get()));
             $dbReport->setRunTime($report->getEndTime() - $report->getStartTime());
             $this->manager->persist($dbReport);
         }


### PR DESCRIPTION
Timezone was not present in the DateTime created from the `$report->getStartTime():`

https://github.com/Cron/Symfony-Bundle/blob/a5f012288581305d66621a58a0e968e74d8cf6c9/Cron/Manager.php#L70

and therefore was not properly saved in database.