### PR TITLE
Fix the type related issues, replace the doc types with PHP type wher…

### DIFF
--- a/Command/CronCreateCommand.php
+++ b/Command/CronCreateCommand.php
@@ -11,12 +11,12 @@ namespace Cron\CronBundle\Command;
 
 use Cron\CronBundle\Cron\CronCommand;
 use Cron\CronBundle\Entity\CronJob;
-use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
-use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Helper\HelperInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
 
 /**
  * @author Dries De Peuter <dries@nousefreak.be>
@@ -26,7 +26,7 @@ class CronCreateCommand extends CronCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('cron:create')
             ->setDescription('Create a cron job')
@@ -37,14 +37,7 @@ class CronCreateCommand extends CronCommand
             ->addOption('enabled', null, InputOption::VALUE_REQUIRED, 'Is the job enabled');
     }
 
-
-    /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $job = new CronJob();
 
@@ -108,11 +101,9 @@ class CronCreateCommand extends CronCommand
     /**
      * Validate the job name.
      *
-     * @param  string                    $name
-     * @return string
      * @throws \InvalidArgumentException
      */
-    protected function validateJobName($name)
+    protected function validateJobName($name): string
     {
         if (!$name || strlen($name) == 0) {
             throw new \InvalidArgumentException('Please set a name.');
@@ -128,11 +119,9 @@ class CronCreateCommand extends CronCommand
     /**
      * Validate the command.
      *
-     * @param  string                    $command
-     * @return string
      * @throws \InvalidArgumentException
      */
-    protected function validateCommand($command)
+    protected function validateCommand(string $command): string
     {
         $parts = explode(' ', $command);
         $this->getApplication()->get((string) $parts[0]);
@@ -143,11 +132,9 @@ class CronCreateCommand extends CronCommand
     /**
      * Validate the schedule.
      *
-     * @param  string                    $schedule
-     * @return string
      * @throws \InvalidArgumentException
      */
-    protected function validateSchedule($schedule)
+    protected function validateSchedule(string $schedule): string
     {
         $this->getContainer()->get('cron.validator')
             ->validate($schedule);
@@ -155,20 +142,13 @@ class CronCreateCommand extends CronCommand
         return $schedule;
     }
 
-    /**
-     * @param  string  $jobName
-     * @return CronJob
-     */
-    protected function queryJob($jobName)
+    protected function queryJob(string $jobName): CronJob
     {
         return $this->getContainer()->get('cron.manager')
             ->getJobByName($jobName);
     }
 
-    /**
-     * @return QuestionHelper
-     */
-    private function getQuestionHelper()
+    private function getQuestionHelper(): HelperInterface
     {
         return $this->getHelperSet()->get('question');
     }

--- a/Command/CronDeleteCommand.php
+++ b/Command/CronDeleteCommand.php
@@ -11,10 +11,11 @@ namespace Cron\CronBundle\Command;
 
 use Cron\CronBundle\Cron\CronCommand;
 use Cron\CronBundle\Entity\CronJob;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Helper\HelperInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * @author Dries De Peuter <dries@nousefreak.be>
@@ -24,21 +25,14 @@ class CronDeleteCommand extends CronCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('cron:delete')
             ->setDescription('Delete a cron job')
             ->addArgument('job', InputArgument::REQUIRED, 'The job to delete');
     }
 
-
-    /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $job = $this->queryJob($input->getArgument('job'));
 
@@ -61,7 +55,7 @@ class CronDeleteCommand extends CronCommand
         );
 
         if (!$this->getQuestionHelper()->ask($input, $output, $question)) {
-            return;
+            return 0;
         }
 
         $this->getContainer()->get('cron.manager')
@@ -72,20 +66,13 @@ class CronDeleteCommand extends CronCommand
         return 0;
     }
 
-    /**
-     * @param  string  $jobName
-     * @return CronJob
-     */
-    protected function queryJob($jobName)
+    protected function queryJob(string $jobName): CronJob
     {
         return $this->getContainer()->get('cron.manager')
             ->getJobByName($jobName);
     }
 
-    /**
-     * @return QuestionHelper
-     */
-    private function getQuestionHelper()
+    private function getQuestionHelper(): HelperInterface
     {
         return $this->getHelperSet()->get('question');
     }

--- a/Command/CronDisableCommand.php
+++ b/Command/CronDisableCommand.php
@@ -23,7 +23,7 @@ class CronDisableCommand extends CronCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('cron:disable')
             ->setDescription('Disable a cron job')
@@ -31,13 +31,7 @@ class CronDisableCommand extends CronCommand
     }
 
 
-    /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $job = $this->queryJob($input->getArgument('job'));
 
@@ -55,11 +49,7 @@ class CronDisableCommand extends CronCommand
         return 0;
     }
 
-    /**
-     * @param  string  $jobName
-     * @return CronJob
-     */
-    protected function queryJob($jobName)
+    protected function queryJob(string $jobName): CronJob
     {
         return $this->getContainer()->get('cron.manager')
             ->getJobByName($jobName);

--- a/Command/CronEnableCommand.php
+++ b/Command/CronEnableCommand.php
@@ -30,14 +30,7 @@ class CronEnableCommand extends CronCommand
             ->addArgument('job', InputArgument::REQUIRED, 'The job to enable');
     }
 
-
-    /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $job = $this->queryJob($input->getArgument('job'));
 
@@ -55,11 +48,7 @@ class CronEnableCommand extends CronCommand
         return 0;
     }
 
-    /**
-     * @param  string  $jobName
-     * @return CronJob
-     */
-    protected function queryJob($jobName)
+    protected function queryJob(string $jobName): CronJob
     {
         return $this->getContainer()->get('cron.manager')
             ->getJobByName($jobName);

--- a/Command/CronListCommand.php
+++ b/Command/CronListCommand.php
@@ -11,10 +11,8 @@ namespace Cron\CronBundle\Command;
 
 use Cron\CronBundle\Cron\CronCommand;
 use Cron\CronBundle\Entity\CronJob;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @author Dries De Peuter <dries@nousefreak.be>
@@ -30,14 +28,7 @@ class CronListCommand extends CronCommand
             ->setDescription('List all available crons');
     }
 
-
-    /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $jobs = $this->queryJobs();
 
@@ -52,7 +43,7 @@ class CronListCommand extends CronCommand
     /**
      * @return CronJob[]
      */
-    protected function queryJobs()
+    protected function queryJobs(): array
     {
         return $this->getContainer()->get('cron.manager')->listJobs();
     }

--- a/Command/CronReportsTruncateCommand.php
+++ b/Command/CronReportsTruncateCommand.php
@@ -10,7 +10,6 @@
 namespace Cron\CronBundle\Command;
 
 use Cron\CronBundle\Cron\CronCommand;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -35,14 +34,7 @@ class CronReportsTruncateCommand extends CronCommand
             );
     }
 
-
-    /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $days = (int)$input->getArgument('days');
 

--- a/Command/CronRunCommand.php
+++ b/Command/CronRunCommand.php
@@ -39,14 +39,7 @@ class CronRunCommand extends CronCommand
             ->addOption('script-name', null, InputOption::VALUE_OPTIONAL, 'Specify this to avoid guessing the script name to run the command in non-CLI context.');
     }
 
-
-    /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $cron = new Cron();
         $cron->setExecutor($this->getContainer()->get('cron.executor'));
@@ -78,12 +71,9 @@ class CronRunCommand extends CronCommand
     }
 
     /**
-     * @param  string                    $jobName
-     * @param  bool                      $force
-     * @return ArrayResolver
      * @throws \InvalidArgumentException
      */
-    protected function getJobResolver($jobName, $force = false, $schedule_now = false)
+    protected function getJobResolver(string $jobName, bool $force = false, $schedule_now = false): ArrayResolver
     {
         $dbJob = $this->queryJob($jobName);
 
@@ -112,11 +102,7 @@ class CronRunCommand extends CronCommand
         return $resolver;
     }
 
-    /**
-     * @param  string  $jobName
-     * @return CronJob
-     */
-    protected function queryJob($jobName)
+    protected function queryJob(string $jobName): CronJob
     {
         $job = $this->getContainer()->get('cron.manager')
             ->getJobByName($jobName);

--- a/Command/CronStartCommand.php
+++ b/Command/CronStartCommand.php
@@ -34,14 +34,7 @@ class CronStartCommand extends CronCommand
             ->addOption('blocking', 'b', InputOption::VALUE_NONE, 'Run in blocking mode.');
     }
 
-
-    /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($input->getOption('blocking')) {
             $output->writeln(sprintf('<info>%s</info>', 'Starting cron scheduler in blocking mode.'));
@@ -77,7 +70,7 @@ class CronStartCommand extends CronCommand
         return 0;
     }
 
-    private function scheduler(OutputInterface $output, $pidFile)
+    private function scheduler(OutputInterface $output, $pidFile): void
     {
         $input = new ArrayInput([]);
 

--- a/Command/CronStopCommand.php
+++ b/Command/CronStopCommand.php
@@ -28,14 +28,7 @@ class CronStopCommand extends CronCommand
             ->setDescription('Stops cron scheduler');
     }
 
-
-    /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $pidFile = sys_get_temp_dir().DIRECTORY_SEPARATOR.CronStartCommand::PID_FILE;
         if (!file_exists($pidFile)) {

--- a/Cron/CommandBuilder.php
+++ b/Cron/CommandBuilder.php
@@ -37,12 +37,7 @@ class CommandBuilder
         $this->phpExecutable = $finder->find();
     }
 
-    /**
-     * @param string $command
-     *
-     * @return string
-     */
-    public function build($command, $scriptName = null)
+    public function build(string $command, $scriptName = null): string
     {
         return sprintf('%s %s %s %s --env=%s', $this->phpExecutable, ' --define max_execution_time='.ini_get('max_execution_time').' --define memory_limit='.ini_get('memory_limit'), $scriptName ?? $_SERVER['SCRIPT_NAME'], $command, $this->environment);
     }

--- a/Cron/CronCommand.php
+++ b/Cron/CronCommand.php
@@ -18,7 +18,7 @@ abstract class CronCommand extends Command
         parent::__construct();
     }
 
-    public function getContainer()
+    public function getContainer(): ContainerInterface
     {
         return $this->container;
     }

--- a/Cron/Manager.php
+++ b/Cron/Manager.php
@@ -14,9 +14,9 @@ use Cron\CronBundle\Entity\CronJobRepository;
 use Cron\CronBundle\Entity\CronReport;
 use Cron\CronBundle\Entity\CronReportRepository;
 use Cron\CronBundle\Job\ShellJobWrapper;
-use Doctrine\Persistence\ManagerRegistry;
 use Cron\Report\JobReport;
 use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * @author Dries De Peuter <dries@nousefreak.be>
@@ -55,7 +55,7 @@ class Manager
     /**
      * @param JobReport[] $reports
      */
-    public function saveReports(array $reports)
+    public function saveReports(array $reports): void
     {
         $connection = $this->manager->getConnection();
         if($connection instanceof Connection && true === method_exists($connection, 'ping') && false === $connection->ping()){
@@ -80,11 +80,8 @@ class Manager
         $this->manager->flush();
     }
 
-    /**
-     * @param int $days
-     */
-    public function truncateReports(int $days = 3)
-    {        
+    public function truncateReports(int $days = 3): void
+    {
         $connection = $this->manager->getConnection();
         if($connection instanceof Connection && true === method_exists($connection, 'ping') && false === $connection->ping()){
             $connection->close();
@@ -116,7 +113,7 @@ class Manager
     /**
      * @return CronJob[]
      */
-    public function listJobs()
+    public function listJobs(): array
     {
         return $this->getJobRepo()
             ->findBy(array(), array(
@@ -127,7 +124,7 @@ class Manager
     /**
      * @return CronJob[]
      */
-    public function listEnabledJobs()
+    public function listEnabledJobs(): array
     {
         return $this->getJobRepo()
             ->findBy(array(
@@ -137,20 +134,13 @@ class Manager
                 ));
     }
 
-    /**
-     * @param CronJob $job
-     */
-    public function saveJob(CronJob $job)
+    public function saveJob(CronJob $job): void
     {
         $this->manager->persist($job);
         $this->manager->flush();
     }
 
-    /**
-     * @param  string  $name
-     * @return CronJob
-     */
-    public function getJobByName($name)
+    public function getJobByName(string $name): CronJob
     {
         return $this->getJobRepo()
             ->findOneBy(array(
@@ -158,10 +148,7 @@ class Manager
                 ));
     }
 
-    /**
-     * @param CronJob $job
-     */
-    public function deleteJob(CronJob $job)
+    public function deleteJob(CronJob $job): void
     {
         $this->manager->remove($job);
         $this->manager->flush();

--- a/Cron/Resolver.php
+++ b/Cron/Resolver.php
@@ -55,7 +55,7 @@ class Resolver implements ResolverInterface
      *
      * @return JobInterface[]
      */
-    public function resolve()
+    public function resolve(): array
     {
         $jobs = $this->manager->listEnabledJobs();
 
@@ -64,21 +64,16 @@ class Resolver implements ResolverInterface
 
     /**
      * Overrides the script name used by the command builder to build the command.
-     *
-     * @param string $scriptName
      */
-    public function setScriptName($scriptName)
+    public function setScriptName(string $scriptName): void
     {
         $this->scriptName = $scriptName;
     }
 
     /**
      * Transform a CronJon into a ShellJob.
-     *
-     * @param  CronJob  $dbJob
-     * @return ShellJob
      */
-    protected function createJob(CronJob $dbJob)
+    protected function createJob(CronJob $dbJob): ShellJob
     {
         $job = new ShellJobWrapper();
         $job->setCommand($this->commandBuilder->build($dbJob->getCommand(), $this->scriptName), $this->rootDir);

--- a/DependencyInjection/CronCronExtension.php
+++ b/DependencyInjection/CronCronExtension.php
@@ -17,7 +17,7 @@ class CronCronExtension extends Extension
     /**
      * {@inheritDoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');


### PR DESCRIPTION
I have a project where I have used this package, and my tests give me the following warnings:
```
Remaining indirect deprecation notices (11)

  1x: Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "Cron\CronBundle\DependencyInjection\CronCronExtension" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in MultiTenancyTest::testAllEntitiesMustImplementTenantAwareInterface from App\Tests\Integration\Entity

  1x: Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "Cron\CronBundle\Command\CronCreateCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in MultiTenancyTest::testAllEntitiesMustImplementTenantAwareInterface from App\Tests\Integration\Entity

  1x: Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "Cron\CronBundle\Command\CronDeleteCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in MultiTenancyTest::testAllEntitiesMustImplementTenantAwareInterface from App\Tests\Integration\Entity

  1x: Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "Cron\CronBundle\Command\CronDisableCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in MultiTenancyTest::testAllEntitiesMustImplementTenantAwareInterface from App\Tests\Integration\Entity

  1x: Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "Cron\CronBundle\Command\CronEnableCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in MultiTenancyTest::testAllEntitiesMustImplementTenantAwareInterface from App\Tests\Integration\Entity

  1x: Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "Cron\CronBundle\Command\CronListCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in MultiTenancyTest::testAllEntitiesMustImplementTenantAwareInterface from App\Tests\Integration\Entity

  1x: Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "Cron\CronBundle\Command\CronReportsTruncateCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in MultiTenancyTest::testAllEntitiesMustImplementTenantAwareInterface from App\Tests\Integration\Entity

  1x: Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "Cron\CronBundle\Command\CronRunCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in MultiTenancyTest::testAllEntitiesMustImplementTenantAwareInterface from App\Tests\Integration\Entity

  1x: Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "Cron\CronBundle\Command\CronStartCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in MultiTenancyTest::testAllEntitiesMustImplementTenantAwareInterface from App\Tests\Integration\Entity

  1x: Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "Cron\CronBundle\Command\CronStopCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in MultiTenancyTest::testAllEntitiesMustImplementTenantAwareInterface from App\Tests\Integration\Entity

```

I thought maybe I could give a hand and try to fix them?!