### PR TITLE
Make Cron/Executor not shared

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -21,6 +21,7 @@ services:
     cron.executor:
         class: "%cron.executor.class%"
         public: true
+        shared: false
     cron.command_builder:
         class: "%cron.command_builder.class%"
         arguments: ["%kernel.environment%"]


### PR DESCRIPTION
fix for issue - https://github.com/Cron/Symfony-Bundle/issues/137 This service should not be shared, to prevent cron jobs accumulating and executing again and again

Closes #137 
Fixes #137 