### PR TITLE
feat: add symfony 8 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,8 @@ jobs:
                     - '8.1'
                     - '8.2'
                     - '8.3'
+                    - '8.4'
+                    - '8.5'
                 symfony-versions: [false]
                 include:
                     -   description: 'Symfony 5.*'
@@ -30,6 +32,9 @@ jobs:
                     -   description: 'Symfony 7.*'
                         php: '8.2'
                         symfony-versions: '^7.0'
+                    -   description: 'Symfony 8.*'
+                        php: '8.4'
+                        symfony-versions: '^8.0'
         name: PHP ${{ matrix.php }} ${{ matrix.description }}
         steps:
             - name: Checkout

--- a/Tests/Command/CronDisableCommandTest.php
+++ b/Tests/Command/CronDisableCommandTest.php
@@ -11,7 +11,6 @@
 namespace Cron\CronBundle\Tests\Command;
 
 use Cron\CronBundle\Command\CronDisableCommand;
-use Cron\CronBundle\Command\CronEnableCommand;
 use Cron\CronBundle\Cron\Manager;
 use Cron\CronBundle\Entity\CronJob;
 use InvalidArgumentException;
@@ -89,9 +88,9 @@ class CronDisableCommandTest extends WebTestCase
         $application = new Application($kernel);
 
         if (method_exists($application, 'addCommand')) {
-            $application->addCommand(new CronEnableCommand($kernel->getContainer()));
+            $application->addCommand(new CronDisableCommand($kernel->getContainer()));
         } else {
-            $application->add(new CronEnableCommand($kernel->getContainer()));
+            $application->add(new CronDisableCommand($kernel->getContainer()));
         }
 
         return $application->find('cron:disable');

--- a/Tests/Command/CronDisableCommandTest.php
+++ b/Tests/Command/CronDisableCommandTest.php
@@ -11,6 +11,7 @@
 namespace Cron\CronBundle\Tests\Command;
 
 use Cron\CronBundle\Command\CronDisableCommand;
+use Cron\CronBundle\Command\CronEnableCommand;
 use Cron\CronBundle\Cron\Manager;
 use Cron\CronBundle\Entity\CronJob;
 use InvalidArgumentException;
@@ -86,7 +87,12 @@ class CronDisableCommandTest extends WebTestCase
         $kernel->getContainer()->set('cron.manager', $manager);
 
         $application = new Application($kernel);
-        $application->addCommand(new CronDisableCommand($kernel->getContainer()));
+
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand(new CronEnableCommand($kernel->getContainer()));
+        } else {
+            $application->add(new CronEnableCommand($kernel->getContainer()));
+        }
 
         return $application->find('cron:disable');
     }

--- a/Tests/Command/CronDisableCommandTest.php
+++ b/Tests/Command/CronDisableCommandTest.php
@@ -86,7 +86,7 @@ class CronDisableCommandTest extends WebTestCase
         $kernel->getContainer()->set('cron.manager', $manager);
 
         $application = new Application($kernel);
-        $application->add(new CronDisableCommand($kernel->getContainer()));
+        $application->addCommand(new CronDisableCommand($kernel->getContainer()));
 
         return $application->find('cron:disable');
     }

--- a/Tests/Command/CronEnableCommandTest.php
+++ b/Tests/Command/CronEnableCommandTest.php
@@ -86,7 +86,12 @@ class CronEnableCommandTest extends WebTestCase
         $kernel->getContainer()->set('cron.manager', $manager);
 
         $application = new Application($kernel);
-        $application->addCommand(new CronEnableCommand($kernel->getContainer()));
+
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand(new CronEnableCommand($kernel->getContainer()));
+        } else {
+            $application->add(new CronEnableCommand($kernel->getContainer()));
+        }
 
         return $application->find('cron:enable');
     }

--- a/Tests/Command/CronEnableCommandTest.php
+++ b/Tests/Command/CronEnableCommandTest.php
@@ -86,7 +86,7 @@ class CronEnableCommandTest extends WebTestCase
         $kernel->getContainer()->set('cron.manager', $manager);
 
         $application = new Application($kernel);
-        $application->add(new CronEnableCommand($kernel->getContainer()));
+        $application->addCommand(new CronEnableCommand($kernel->getContainer()));
 
         return $application->find('cron:enable');
     }

--- a/Tests/Command/CronRunCommandTest.php
+++ b/Tests/Command/CronRunCommandTest.php
@@ -10,7 +10,6 @@
 
 namespace Cron\CronBundle\Tests\Command;
 
-use Cron\CronBundle\Command\CronEnableCommand;
 use Cron\CronBundle\Command\CronRunCommand;
 use Cron\CronBundle\Cron\Manager;
 use Cron\CronBundle\Cron\Resolver;
@@ -110,9 +109,9 @@ class CronRunCommandTest extends WebTestCase
         $application = new Application($kernel);
 
         if (method_exists($application, 'addCommand')) {
-            $application->addCommand(new CronEnableCommand($kernel->getContainer()));
+            $application->addCommand(new CronRunCommand($kernel->getContainer()));
         } else {
-            $application->add(new CronEnableCommand($kernel->getContainer()));
+            $application->add(new CronRunCommand($kernel->getContainer()));
         }
 
         return $application->find('cron:run');

--- a/Tests/Command/CronRunCommandTest.php
+++ b/Tests/Command/CronRunCommandTest.php
@@ -107,7 +107,7 @@ class CronRunCommandTest extends WebTestCase
         $kernel->getContainer()->set('cron.resolver', $resolver);
 
         $application = new Application($kernel);
-        $application->add(new CronRunCommand($kernel->getContainer()));
+        $application->addCommand(new CronRunCommand($kernel->getContainer()));
 
         return $application->find('cron:run');
     }

--- a/Tests/Command/CronRunCommandTest.php
+++ b/Tests/Command/CronRunCommandTest.php
@@ -10,6 +10,7 @@
 
 namespace Cron\CronBundle\Tests\Command;
 
+use Cron\CronBundle\Command\CronEnableCommand;
 use Cron\CronBundle\Command\CronRunCommand;
 use Cron\CronBundle\Cron\Manager;
 use Cron\CronBundle\Cron\Resolver;
@@ -107,7 +108,12 @@ class CronRunCommandTest extends WebTestCase
         $kernel->getContainer()->set('cron.resolver', $resolver);
 
         $application = new Application($kernel);
-        $application->addCommand(new CronRunCommand($kernel->getContainer()));
+
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand(new CronEnableCommand($kernel->getContainer()));
+        } else {
+            $application->add(new CronEnableCommand($kernel->getContainer()));
+        }
 
         return $application->find('cron:run');
     }

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
         "doctrine/dbal": "*",
         "doctrine/orm": ">=2.4.5",
         "doctrine/persistence": "*",
-        "symfony/config": "^5.0|^6.0|^7.0",
-        "symfony/console": "^5.0|^6.0|^7.0",
-        "symfony/dependency-injection": "^5.0|^6.0|^7.0",
-        "symfony/http-kernel": "^5.0|^6.0|^7.0",
-        "symfony/process": "^5.0|^6.0|^7.0",
-        "symfony/lock": "^5.0|^6.0|^7.0"
+        "symfony/config": "^5.0|^6.0|^7.0|^8.0",
+        "symfony/console": "^5.0|^6.0|^7.0|^8.0",
+        "symfony/dependency-injection": "^5.0|^6.0|^7.0|^8.0",
+        "symfony/http-kernel": "^5.0|^6.0|^7.0|^8.0",
+        "symfony/process": "^5.0|^6.0|^7.0|^8.0",
+        "symfony/lock": "^5.0|^6.0|^7.0|^8.0"
     },
     "autoload": {
         "psr-4" : {
@@ -45,8 +45,8 @@
         "doctrine/doctrine-bundle": "*",
         "monolog/monolog": "*",
         "phpunit/phpunit": "^10",
-        "symfony/security-csrf": "^5.0|^6.0|^7.0",
-        "symfony/translation": "^5.0|^6.0|^7.0",
-        "symfony/yaml": "^5.0|^6.0|^7.0"
+        "symfony/security-csrf": "^5.0|^6.0|^7.0|^8.0",
+        "symfony/translation": "^5.0|^6.0|^7.0|^8.0",
+        "symfony/yaml": "^5.0|^6.0|^7.0|^8.0"
     }
 }


### PR DESCRIPTION
In this PR I add symfony 8 support for the cron bundle. The tests are updated and all work.

In https://github.com/symfony/symfony/commit/0fbcaa1f79734bf99fd3b635395eb697e5d83bec the add() method gets removed in favor of addCommand()

What I did:

- Updated the symfony dependency
- Replaced removed add() method with addCommand()