### PR TITLE
docs: fix 4 typos in commands and resolver

### DIFF
--- a/Command/CronCreateCommand.php
+++ b/Command/CronCreateCommand.php
@@ -94,7 +94,7 @@ class CronCreateCommand extends CronCommand
             ->saveJob($job);
 
         $output->writeln('');
-        $output->writeln(sprintf('<info>Cron "%s" was created..</info>', $job->getName()));
+        $output->writeln(sprintf('<info>Cron "%s" was created.</info>', $job->getName()));
 
         return 0;
     }

--- a/Command/CronRunCommand.php
+++ b/Command/CronRunCommand.php
@@ -35,10 +35,10 @@ class CronRunCommand extends CronCommand
     protected function configure(): void
     {
         $this->setName('cron:run')
-            ->setDescription('Runs any currently schedule cron jobs')
+            ->setDescription('Runs any currently scheduled cron jobs')
             ->addArgument('job', InputArgument::OPTIONAL, 'Run only this job (if enabled)')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Force schedule the current job.')
-            ->addOption('schedule_now', null, InputOption::VALUE_NONE, 'Temporary set the job schedule to now.')
+            ->addOption('schedule_now', null, InputOption::VALUE_NONE, 'Temporarily set the job schedule to now.')
             ->addOption('script-name', null, InputOption::VALUE_OPTIONAL, 'Specify this to avoid guessing the script name to run the command in non-CLI context.');
     }
 

--- a/Cron/Resolver.php
+++ b/Cron/Resolver.php
@@ -52,7 +52,7 @@ class Resolver implements ResolverInterface
     }
 
     /**
-     * Transform a CronJon into a ShellJob.
+     * Transform a CronJob into a ShellJob.
      */
     protected function createJob(CronJob $dbJob): ShellJob
     {


### PR DESCRIPTION
## Summary

Fix 4 typos across 3 files:

- **Command/CronCreateCommand.php**: fix double period "created.." → "created."
- **Command/CronRunCommand.php**: fix "schedule cron" → "scheduled cron" (missing -d), "Temporary set" → "Temporarily set" (wrong part of speech)
- **Cron/Resolver.php**: fix "CronJon" → "CronJob"

No functional changes — strings and comments only.